### PR TITLE
Infer schema for items of .resources. Closes #3.

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,6 +56,7 @@ module.exports = function(url, options) {
                     hash     : R.hash,
                     mediatype: R.format,
                     name     : R.name,
+                    schema   : R.schema,
                     url      : R.url
                   }; })
                 };

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var _ = require('underscore');
 var async = require('async');
-var getUri = require('get-uri');
-var jtsInfer = require('jts-infer');
+var csv = require('csv');
+var infer = require('json-table-schema').infer;
 var Promise = require('promise-polyfill');
 var request = require('superagent');
 var validator = require('validator');
@@ -69,15 +69,12 @@ module.exports = function(url, options) {
 
                   // Not sure which exactly .resources[] property specifies mime type
                   if(!schema && _.contains([R.format, R.mimetype], 'text/csv'))
-                    request.get(R.url).end(function(E, R) {
-                      // jts-infer require streamable input
-                      getUri('data:text/csv:utf-8' + ',' + R.text, function (ER, ST) {
-                        jtsInfer(ST, function(EJ, S, SR) {
-                          if(EJ)
-                            CB(null, resource);
+                    request.get(R.url).end(function(E, RS) {
+                      csv.parse(RS.text, function(EJ, D) {
+                        if(EJ)
+                          CB(null, resource);
 
-                          CB(null, _.extend(resource, {schema: S}));
-                        });
+                        CB(null, _.extend(resource, {schema: infer(D[0], _.rest(D))}));
                       });
                     });
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "async": "^1.2.1",
     "csv": "^0.4.5",
-    "json-table-schema": "0.0.1-alpha",
+    "json-table-schema": "0.0.2-alpha",
     "promise-polyfill": "^2.0.2",
     "superagent": "^1.2.0",
     "underscore": "^1.8.3",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "keywords": [],
   "main": "index.js",
   "dependencies": {
+    "async": "^1.2.1",
+    "get-uri": "^0.1.3",
+    "jts-infer": "0.0.0",
     "promise-polyfill": "^2.0.2",
     "superagent": "^1.2.0",
     "underscore": "^1.8.3",
@@ -14,7 +17,9 @@
     "chai": "^3.0.0",
     "chai-spies": "^0.6.0",
     "mocha": "^2.2.5",
+    "promise-polyfill": "^2.0.2",
     "query-string": "^2.3.0",
+    "superagent": "^1.2.0",
     "superagent-mock": "^1.2.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "main": "index.js",
   "dependencies": {
     "async": "^1.2.1",
-    "get-uri": "^0.1.3",
-    "jts-infer": "0.0.0",
+    "csv": "^0.4.5",
+    "json-table-schema": "0.0.1-alpha",
     "promise-polyfill": "^2.0.2",
     "superagent": "^1.2.0",
     "underscore": "^1.8.3",

--- a/test-data.js
+++ b/test-data.js
@@ -83,7 +83,7 @@ module.exports.CKAN_V3_ENDPOINT_RESPONSE = {
         'state': 'active',
         'hash': '321',
         'description': '',
-        'format': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        'format': 'text/csv',
         'tracking_summary': {'total': 0, 'recent': 0},
         'mimetype_inner': null,
         'mimetype': null,
@@ -229,16 +229,16 @@ module.exports.CKAN_V3_BASE_DATAPACKAGE = {
   'resources': [
     {
       'name': 'Central Informatics Organisation',
-      'url': 'https://ckannet-storage.commondatastorage.googleapis.com/2015-06-04T09:12:06.147Z/populationnumber-by-governorates-age-group-gender.xlsx',
-      'mediatype': 'microsoft excel',
+      'url': 'https://ckannet-storage.commondatastorage.googleapis.com/2015-06-04T09:12:06.147Z/populationnumber-by-governorates-age-group-gender.csv',
+      'mediatype': 'text/csv',
       'hash': '123',
       'schema': module.exports.VALID_TABLE_SCHEMA
     },
 
     {
       'name': null,
-      'url': 'https://ckannet-storage.commondatastorage.googleapis.com/2015-06-04T09:12:06.147Z/populationnumber-by-governorates-age-group-gender-3.xlsx',
-      'mediatype': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      'url': 'https://ckannet-storage.commondatastorage.googleapis.com/2015-06-04T09:12:06.147Z/populationnumber-by-governorates-age-group-gender-3.csv',
+      'mediatype': 'text/csv',
       'hash': '321',
       'schema': module.exports.VALID_TABLE_SCHEMA
     },

--- a/test-data.js
+++ b/test-data.js
@@ -1,3 +1,30 @@
+module.exports.VALID_TABLE_SCHEMA = {
+  'fields': [
+    {
+      'name': 'id',
+      'title': 'ID',
+      'type': 'integer',
+      'description': 'The id.'
+    },
+
+    {
+      'name': 'name',
+      'title': 'Name',
+      'type': 'string',
+      'description': 'The name.'
+    },
+
+    {
+      'name': 'age',
+      'title': 'Age',
+      'type': 'integer',
+      'description': 'The age.'
+    }
+  ],
+  
+  'primaryKey': 'id'
+};
+
 module.exports.CKAN_V3_ENDPOINT_RESPONSE = {
   'help': 'Return the metadata of a dataset (package) and its resources.\n\n    :param id: the id or name of the dataset\n    :type id: string\n\n    :rtype: dictionary\n\n    ',
   'success': true,
@@ -68,7 +95,8 @@ module.exports.CKAN_V3_ENDPOINT_RESPONSE = {
         'last_modified': null,
         'position': 1,
         'revision_id': '41366b22-27eb-49c9-90f7-0a71e9a9c8a2',
-        'resource_type': 'file.upload'
+        'resource_type': 'file.upload',
+        'schema': {'invalid': 'schema example'}
       },
 
       {
@@ -91,7 +119,8 @@ module.exports.CKAN_V3_ENDPOINT_RESPONSE = {
         'webstore_url': null,
         'last_modified': null,
         'position': 2, 'revision_id': '22e49b1c-12df-4b2f-9ce5-efc5bf2e5585',
-        'resource_type': 'file.upload'
+        'resource_type': 'file.upload',
+        'schema': module.exports.VALID_TABLE_SCHEMA
       }
     ],
 

--- a/test-data.js
+++ b/test-data.js
@@ -58,14 +58,14 @@ module.exports.CKAN_V3_ENDPOINT_RESPONSE = {
         'state': 'active',
         'hash': '123',
         'description': '',
-        'format': 'microsoft excel',
+        'format': 'text/csv',
         'tracking_summary': {'total': 0, 'recent': 0},
         'mimetype_inner': null,
         'mimetype': 'null',
         'cache_url': null,
         'name': 'Central Informatics Organisation',
         'created': '2015-06-04T09:11:20.451894',
-        'url': 'https://ckannet-storage.commondatastorage.googleapis.com/2015-06-04T09:12:06.147Z/populationnumber-by-governorates-age-group-gender.xlsx',
+        'url': 'https://ckannet-storage.commondatastorage.googleapis.com/2015-06-04T09:12:06.147Z/populationnumber-by-governorates-age-group-gender.csv',
         'webstore_url': null,
         'last_modified': null,
         'position': 0,
@@ -90,7 +90,7 @@ module.exports.CKAN_V3_ENDPOINT_RESPONSE = {
         'cache_url': null,
         'name': null,
         'created': '2015-06-04T09:11:25.017302',
-        'url': 'https://ckannet-storage.commondatastorage.googleapis.com/2015-06-04T09:12:06.147Z/populationnumber-by-governorates-age-group-gender-3.xlsx',
+        'url': 'https://ckannet-storage.commondatastorage.googleapis.com/2015-06-04T09:12:06.147Z/populationnumber-by-governorates-age-group-gender-3.csv',
         'webstore_url': null,
         'last_modified': null,
         'position': 1,
@@ -231,21 +231,24 @@ module.exports.CKAN_V3_BASE_DATAPACKAGE = {
       'name': 'Central Informatics Organisation',
       'url': 'https://ckannet-storage.commondatastorage.googleapis.com/2015-06-04T09:12:06.147Z/populationnumber-by-governorates-age-group-gender.xlsx',
       'mediatype': 'microsoft excel',
-      'hash': '123'
+      'hash': '123',
+      'schema': module.exports.VALID_TABLE_SCHEMA
     },
 
     {
       'name': null,
       'url': 'https://ckannet-storage.commondatastorage.googleapis.com/2015-06-04T09:12:06.147Z/populationnumber-by-governorates-age-group-gender-3.xlsx',
       'mediatype': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-      'hash': '321'
+      'hash': '321',
+      'schema': module.exports.VALID_TABLE_SCHEMA
     },
 
     {
       'name': null,
       'url': 'https://ckannet-storage.commondatastorage.googleapis.com/2015-06-04T09:13:26.344Z/populationnumber-by-governorates-age-group-gender-5.xlsx',
       'mediatype': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-      'hash': '111'
+      'hash': '111',
+      'schema': module.exports.VALID_TABLE_SCHEMA
     }
   ],
 

--- a/test-data.js
+++ b/test-data.js
@@ -2,9 +2,9 @@ module.exports.VALID_CSV = 'id,name,age\n1,John,33\n7,Jane,25';
 
 module.exports.VALID_TABLE_SCHEMA = {
   'fields': [
-    {'name': 'id', 'type': 'integer'},
-    {'name': 'name', 'type': 'string'},
-    {'name': 'age', 'type': 'integer'}
+    {'name': 'id', 'type': 'integer', 'title': '', 'description': '', 'format': 'default'},
+    {'name': 'name', 'type': 'string', 'title': '', 'description': '', 'format': 'default'},
+    {'name': 'age', 'type': 'integer', 'title': '', 'description': '', 'format': 'default'}
   ]
 };
 

--- a/test-data.js
+++ b/test-data.js
@@ -1,28 +1,11 @@
+module.exports.VALID_CSV = 'id,name,age\n1,John,33\n7,Jane,25';
+
 module.exports.VALID_TABLE_SCHEMA = {
   'fields': [
-    {
-      'name': 'id',
-      'title': 'ID',
-      'type': 'integer',
-      'description': 'The id.'
-    },
-
-    {
-      'name': 'name',
-      'title': 'Name',
-      'type': 'string',
-      'description': 'The name.'
-    },
-
-    {
-      'name': 'age',
-      'title': 'Age',
-      'type': 'integer',
-      'description': 'The age.'
-    }
-  ],
-  
-  'primaryKey': 'id'
+    {'name': 'id', 'type': 'integer'},
+    {'name': 'name', 'type': 'string'},
+    {'name': 'age', 'type': 'integer'}
+  ]
 };
 
 module.exports.CKAN_V3_ENDPOINT_RESPONSE = {
@@ -96,7 +79,7 @@ module.exports.CKAN_V3_ENDPOINT_RESPONSE = {
         'position': 1,
         'revision_id': '41366b22-27eb-49c9-90f7-0a71e9a9c8a2',
         'resource_type': 'file.upload',
-        'schema': {'invalid': 'schema example'}
+        'schema': module.exports.VALID_TABLE_SCHEMA
       },
 
       {
@@ -119,8 +102,7 @@ module.exports.CKAN_V3_ENDPOINT_RESPONSE = {
         'webstore_url': null,
         'last_modified': null,
         'position': 2, 'revision_id': '22e49b1c-12df-4b2f-9ce5-efc5bf2e5585',
-        'resource_type': 'file.upload',
-        'schema': module.exports.VALID_TABLE_SCHEMA
+        'resource_type': 'file.upload'
       }
     ],
 
@@ -247,8 +229,7 @@ module.exports.CKAN_V3_BASE_DATAPACKAGE = {
       'name': null,
       'url': 'https://ckannet-storage.commondatastorage.googleapis.com/2015-06-04T09:13:26.344Z/populationnumber-by-governorates-age-group-gender-5.xlsx',
       'mediatype': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-      'hash': '111',
-      'schema': module.exports.VALID_TABLE_SCHEMA
+      'hash': '111'
     }
   ],
 

--- a/test.js
+++ b/test.js
@@ -86,4 +86,9 @@ describe('Datapackage from remote', function() {
       done();
     });
   });
+
+  it('infer schema for resources with no schema specified', function(done, err) {
+    if(err) done(err);
+    true.should.be.false;
+  });
 });

--- a/test.js
+++ b/test.js
@@ -1,3 +1,4 @@
+var _ = require('underscore');
 var assert = require('chai').assert;
 var chai = require('chai');
 var fromRemote = require('./index');
@@ -9,6 +10,18 @@ var TEST_DATA = require('./test-data');
 
 
 describe('Datapackage from remote', function() {
+  // Do not test schema infer in some test case
+  var responseWithSchema = _.extend(
+    {}, TEST_DATA.CKAN_V3_ENDPOINT_RESPONSE,
+
+    {result: _.extend({}, TEST_DATA.CKAN_V3_ENDPOINT_RESPONSE.result, {
+      resources: TEST_DATA.CKAN_V3_ENDPOINT_RESPONSE.result.resources.map(function(R) {
+        return _.extend({}, R, {schema: TEST_DATA.VALID_TABLE_SCHEMA});
+      })
+    })}
+  );
+
+
   it('throw exception if no url or empty url passed in params', function(done, err) {
     if(err) done(err);
 
@@ -62,7 +75,7 @@ describe('Datapackage from remote', function() {
 
     requestMock(request, [{
       callback: function (match, data) { return {body: data}; },
-      fixtures: function (match, params) { return TEST_DATA.CKAN_V3_ENDPOINT_RESPONSE; },
+      fixtures: function (match, params) { return responseWithSchema; },
       pattern: '.*'
     }]);
 
@@ -77,7 +90,7 @@ describe('Datapackage from remote', function() {
 
     requestMock(request, [{
       callback: function (match, data) { return {body: data}; },
-      fixtures: function (match, params) { return TEST_DATA.CKAN_V3_ENDPOINT_RESPONSE; },
+      fixtures: function (match, params) { return responseWithSchema; },
       pattern: '.*'
     }]);
 

--- a/test.js
+++ b/test.js
@@ -87,8 +87,32 @@ describe('Datapackage from remote', function() {
     });
   });
 
-  it('infer schema for resources with no schema specified', function(done, err) {
+  it('infer schema for resources with no schema specified or invalid schema', function(done, err) {
     if(err) done(err);
-    true.should.be.false;
+
+    requestMock(request, [{
+      callback: function (match, data) { return {body: data}; },
+      fixtures: function (match, params) { return TEST_DATA.CKAN_V3_ENDPOINT_RESPONSE; },
+      pattern: '.*'
+    }]);
+
+    // Resource with empty schema, but in csv format    
+    requestMock(request, [{
+      callback: function (match, data) { return {body: data}; },
+      fixtures: function (match, params) { return TEST_DATA.VALID_TABLE_SCHEMA; },
+      pattern: 'https://ckannet-storage.commondatastorage.googleapis.com/2015-06-04T09:12:06.147Z/populationnumber-by-governorates-age-group-gender.csv'
+    }]);
+    
+    // Resource in csv format with invalid schema
+    requestMock(request, [{
+      callback: function (match, data) { return {body: data}; },
+      fixtures: function (match, params) { return TEST_DATA.VALID_TABLE_SCHEMA; },
+      pattern: 'https://ckannet-storage.commondatastorage.googleapis.com/2015-06-04T09:12:06.147Z/populationnumber-by-governorates-age-group-gender-3.csv'
+    }]);
+
+    fromRemote('http://valid.url.com').then(function(DP) {
+      DP.should.be.deep.equal(TEST_DATA.CKAN_V3_BASE_DATAPACKAGE);
+      done();
+    });
   });
 });

--- a/test.js
+++ b/test.js
@@ -10,13 +10,13 @@ var TEST_DATA = require('./test-data');
 
 
 describe('Datapackage from remote', function() {
-  // Do not test schema infer in some test case
+  // Test schema infer only in one specific test case
   var responseWithSchema = _.extend(
     {}, TEST_DATA.CKAN_V3_ENDPOINT_RESPONSE,
 
     {result: _.extend({}, TEST_DATA.CKAN_V3_ENDPOINT_RESPONSE.result, {
       resources: TEST_DATA.CKAN_V3_ENDPOINT_RESPONSE.result.resources.map(function(R) {
-        return _.extend({}, R, {schema: TEST_DATA.VALID_TABLE_SCHEMA});
+        return _.extend({}, R, R.format == 'text/csv' && {schema: TEST_DATA.VALID_TABLE_SCHEMA});
       })
     })}
   );
@@ -111,15 +111,15 @@ describe('Datapackage from remote', function() {
 
     // Resource with empty schema, but in csv format    
     requestMock(request, [{
-      callback: function (match, data) { return {body: data}; },
-      fixtures: function (match, params) { return TEST_DATA.VALID_TABLE_SCHEMA; },
+      callback: function (match, data) { return {text: data}; },
+      fixtures: function (match, params) { return TEST_DATA.VALID_CSV; },
       pattern: 'https://ckannet-storage.commondatastorage.googleapis.com/2015-06-04T09:12:06.147Z/populationnumber-by-governorates-age-group-gender.csv'
     }]);
     
     // Resource in csv format with invalid schema
     requestMock(request, [{
-      callback: function (match, data) { return {body: data}; },
-      fixtures: function (match, params) { return TEST_DATA.VALID_TABLE_SCHEMA; },
+      callback: function (match, data) { return {text: data}; },
+      fixtures: function (match, params) { return TEST_DATA.VALID_CSV; },
       pattern: 'https://ckannet-storage.commondatastorage.googleapis.com/2015-06-04T09:12:06.147Z/populationnumber-by-governorates-age-group-gender-3.csv'
     }]);
 


### PR DESCRIPTION
Infer schema using https://www.npmjs.com/package/jts-infer for items of `.resources[]` which has mime type equal to `text/csv` and empty or non-object type `.schema`.
