### PR TITLE
potentially resolves okfn/datapackagist#165

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,11 +84,11 @@ module.exports = function(url, options) {
               }
             }
           },
-		dkan: {
+          dkan: {
             '3.0': {
               base: function(input) {
-				
-				//work around DKAN's results array implementation of package_show api
+
+                //work around DKAN's results array implementation of package_show api
                 var result = input.result[0];
 
                 var datapackage = {
@@ -137,8 +137,7 @@ module.exports = function(url, options) {
               }
             }
           }
-        
-		})[that.options.source][that.options.version][
+        })[that.options.source][that.options.version][
           that.options.datapackage.replace('tabular', 'base')
         ](R.body);
       });

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var _ = require('underscore');
 var async = require('async');
 var csv = require('csv');
 var infer = require('json-table-schema').infer;
-var Promise = require('bluebird');
+var Promise = require('promise-polyfill');
 var request = require('superagent');
 var validator = require('validator');
 
@@ -83,8 +83,62 @@ module.exports = function(url, options) {
                 }, function(E, R) { RS(_.extend(datapackage, {resources: R})); });
               }
             }
+          },
+		dkan: {
+            '3.0': {
+              base: function(input) {
+				
+				//work around DKAN's results array implementation of package_show api
+                var result = input.result[0];
+
+                var datapackage = {
+                  name            : result.name,
+                  title           : result.title,
+                  description     : result.notes,
+                  homepage        : '',
+                  version         : result.version,
+                  licences        : [{id: result.license_id, url: result.license_url}],
+                  author          : _.compact([result.author, result.author_email]).join(' '),
+                  contributors    : [],
+                  sources         : [],
+                  image           : '',
+                  base            : '',
+                  dataDependencies: {},
+                  keywords        : _.pluck(result.tags, 'name')
+                };
+
+
+                // Get each resource in async and infer it's schema
+                async.map(result.resources, function(R, CB) {
+                  var resource = {
+                    hash     : R.hash,
+                    mediatype: R.format,
+                    name     : R.name,
+                    url      : R.url
+                  };
+
+                  var schema = _.isObject(R.schema) && !_.isArray(R.schema) && R.schema;
+
+
+                  // Not sure which exactly .resources[] property specifies mime type
+                  if(!schema && _.contains([R.format, R.mimetype], 'text/csv'))
+                    request.get(R.url).end(function(E, RS) {
+                      csv.parse(RS.text, function(EJ, D) {
+                        if(EJ)
+                          CB(null, resource);
+
+                        CB(null, _.extend(resource, {schema: infer(D[0], _.rest(D))}));
+                      });
+                    });
+
+                  else
+                    CB(null, _.extend(resource, schema && {schema: schema}));
+                }, function(E, R) { RS(_.extend(datapackage, {resources: R})); });
+              }
+            }
           }
-        })[that.options.source][that.options.version][
+        
+		})[that.options.source][that.options.version][
           that.options.datapackage.replace('tabular', 'base')
         ](R.body);
       });


### PR DESCRIPTION
@pwalsh This illustrates potential workaround for issue okfn/datapackagist#165 to specify a separate DKAN source which accounts for the package_show results hash being wrapped in an array.

On my local build I can now read CKAN and DKAN sources.

The code is probably a bit clumsy (not very DRY!) and I'm not sure of the distinction between bluebird and promise-polyfill.  That reflects the fact I hacked about the npm-installed index file in datapackagist\node_modules\datapackage-from-remote directory and then copied the code across to this repo...
